### PR TITLE
[NO-ISSUE] Remove hpqtypes dependency

### DIFF
--- a/scrive-prelude.cabal
+++ b/scrive-prelude.cabal
@@ -64,6 +64,7 @@ library
     , exceptions
     , extra
     , fields-json
+    , hpqtypes
     , optics
     , pretty-simple
     , text

--- a/scrive-prelude.cabal
+++ b/scrive-prelude.cabal
@@ -64,7 +64,6 @@ library
     , exceptions
     , extra
     , fields-json
-    , hpqtypes
     , optics
     , pretty-simple
     , text

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -11,7 +11,6 @@ module Prelude
   , module Data.List
   , module Data.Maybe
   , module Data.Monoid
-  , module Data.Monoid.Utils
   , module O
   , module P
   , Generic
@@ -80,7 +79,6 @@ import Data.List hiding
 import Data.Maybe hiding (fromJust)
 import qualified Data.Maybe.Optics as O
 import Data.Monoid
-import Data.Monoid.Utils
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -17,8 +17,6 @@ module Prelude
   , Text
   , MonadFail (..)
   , (!!)
-  -- hpqtypes
-  , (<+>)
   -- optics
   , (&)
   , (%)
@@ -81,7 +79,6 @@ import Data.List hiding
 import Data.Maybe hiding (fromJust)
 import qualified Data.Maybe.Optics as O
 import Data.Monoid
-import Data.Monoid.Utils
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -17,6 +17,8 @@ module Prelude
   , Text
   , MonadFail (..)
   , (!!)
+  -- hpqtypes
+  , (<+>)
   -- optics
   , (&)
   , (%)
@@ -79,6 +81,7 @@ import Data.List hiding
 import Data.Maybe hiding (fromJust)
 import qualified Data.Maybe.Optics as O
 import Data.Monoid
+import Data.Monoid.Utils
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL


### PR DESCRIPTION
This PR proposes to remove `hpqtypes` dependency.
Here is the (simplified) diff between the two `cabal.project.freeze` files obtained from the `main` branch and the `remove-hpqtypes` branch:
```patch
-             any.QuickCheck ==2.14.2,
-             any.StateVar ==1.2.2,
-             any.aeson ==2.1.1.0,
-             any.assoc ==1.0.2,
-             any.async ==2.2.4,
-             any.attoparsec ==0.14.4,
-             any.base-compat ==0.12.2,
-             any.base-compat-batteries ==0.12.2,
-             any.base-orphans ==0.8.7,
-             any.bifunctors ==5.5.14,
-             any.bytestring-builder ==0.10.8.2.0,
-             any.comonad ==5.0.8,
-             any.contravariant ==1.5.5,
-             any.data-fix ==0.3.2,
-             any.distributive ==0.6.2.1,
-             any.dlist ==1.0,
-             any.generic-deriving ==1.14.2,
-             any.generically ==0.1,
-             any.hpqtypes ==1.11.0.0,
-             any.hsc2hs ==0.68.8,
-             any.integer-logarithms ==1.0.3.1,
-             any.lifted-base ==0.2.3.12,
-             any.monad-control ==1.0.3.1,
-             any.random ==1.2.1.1,
-             any.resource-pool ==0.4.0.0,
-             any.scientific ==0.3.7.0,
-             any.semialign ==1.2.0.1,
-             any.semigroupoids ==5.3.7,
-             any.semigroups ==0.20,
-             any.splitmix ==0.1.0.4,
-             any.strict ==0.4.0.1,
-             any.text-short ==0.1.5,
-             any.text-show ==3.10,
-             any.th-lift ==0.8.2,
-             any.these ==1.1.1.1,
-             any.time-compat ==1.9.6.1,
-             any.transformers-base ==0.4.6,
-             any.uuid-types ==1.0.5,
-             any.vector-stream ==0.1.0.0,
-             any.witherable ==0.4.2
+             any.vector-stream ==0.1.0.0
```

The reason for having the dependency to `hpqtypes` is to re-export the `Data.Monoid.Utils`.